### PR TITLE
Fix: Bug fix

### DIFF
--- a/core/config.mk
+++ b/core/config.mk
@@ -900,7 +900,7 @@ endif
 ifneq ($(SM_BUILD),)
 ## We need to be sure the global selinux policies are included
 ## last, to avoid accidental resetting by device configs
-$(eval include device/sm/sepolicy/common/sepolicy.mk)
+$(eval include device/lineage/sepolicy/common/sepolicy.mk)
 
 # Include any vendor specific config.mk file
 -include $(TOPDIR)vendor/*/build/core/config.mk


### PR DESCRIPTION
The global sepolicy rule path error that needs to be included causes the compiler to stop, and now correct the problem.

Change-Id: I3767f65a1d956124f8dbe5a2ddbeae3d687e9289
Signed-off-by: gesangtome <gesangtome@foxmail.com>